### PR TITLE
Make compatible with autoreload tools

### DIFF
--- a/src/Remark.jl
+++ b/src/Remark.jl
@@ -44,7 +44,7 @@ function slideshow(inputfile, outputdir = dirname(inputfile);
 
         mv(workingdir, outputdir, force=true)
     end
-    return outputdir
+    return realpath(abspath(outputdir))
 end
 
 function _create_index_md(inputfile, outputdir; documenter = true)
@@ -82,7 +82,7 @@ function _create_index_html(outputdir, md_file, options = Dict(); title = "Title
     template = joinpath(_pkg_assets, "indextemplate.html")
     replacements = ["\$title" => title, "\$options" => optionsjs]
 
-    Base.open(joinpath(outputdir, "build", "index.html"), "a") do io
+    Base.open(joinpath(outputdir, "build", "index.html"), "w") do io
         for line in eachline(template, keep=true)
             if occursin("\$presentation", line)
                 Base.open(md -> write(io, md), md_file)

--- a/src/Remark.jl
+++ b/src/Remark.jl
@@ -33,7 +33,10 @@ function slideshow(inputfile, outputdir = dirname(inputfile);
     # reload script afterwards, so stop working.
     # to solve this we move everything in place at the end as a single fast operation
     mktempdir() do tempdir
-        workingdir = realpath(abspath(mkpath(joinpath(tempdir, "working"))))
+        # cp is required if `outputdir` is not empty.
+        workingdir = realpath(abspath(cp(outputdir, joinpath(tempdir, "working"))))
+
+
         inputfile = realpath(abspath(inputfile))
         css = realpath(abspath(css))
         mkpath.(joinpath.(workingdir, ("src", "build")))


### PR DESCRIPTION
This is kind of the other half of #37 
so with this setup i can use, e.g. VS-Code's LiveServer Plugin,
or a normal webserver + Live.js, or like just inserting `<meta... refresh>` stuff,
to have the webpage reload when the HTML file changes.

The thing that was breaking it before was that Documenter deletes the whole build directory at that start, which means there is maybe 1 second or 3 where there is no file.
I tried like 3 different auto-relaod tools and none of them can deal with this, because they all trigger the reload by inserting javascript to do the refresh into the page itself, but if the page is gone after refresh then there is no javascript to run to refresh again
