### PR TITLE
use mkpath instead of mkdir

### DIFF
--- a/src/Remark.jl
+++ b/src/Remark.jl
@@ -54,7 +54,7 @@ function slideshow(presentation_dir;
         Base.open(joinpath(workingdir, "build", "style.css"), "w") do io
             foreach(file -> Base.open(content -> write(io, content), file), css_list)
         end
-        isdir(assets_dir) && transcribe(assets_dir, mkdir(joinpath(workingdir, "build", "assets")))
+        isdir(assets_dir) && transcribe(assets_dir, mkpath(joinpath(workingdir, "build", "assets")))
         mv(joinpath(workingdir, "build"), joinpath(presentation_dir, "build"), force=true)
     end
     return presentation_dir


### PR DESCRIPTION
Hi, @piever 

This PR fixes the error for [the case](https://github.com/piever/Remark.jl#external-assets-styling-and-customization). Namely, when one adds `assets` directory inside `src`, it fails with the following error message:

```
ERROR: IOError: mkdir("/var/folders/14/cg438fvd28dg9wpvpwt1lz0c0000gn/T/jl_0rxxcD/build/assets"; mode=0o777): file already exists (EEXIST)
```

I've found that `</path/to/tmp/dir>/build/assets` is generated by `Documenter.makedocs(format=DocumenterMarkdown.Markdown(), root=outputdir)`.
This happens when `documenter` is `true`

See:

https://github.com/piever/Remark.jl/blob/e64723af9259435abc5b394be7fff2a47eb2149a/src/Remark.jl#L73-L88

I think it is a good idea to use `mkpath` rather than `mkdir`.

