### PR TITLE
Removing BuildProvider dependency given it does not work in M1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ authors = ["Pietro Vertechi"]
 version = "0.3.2"
 
 [deps]
-BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
+CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 DefaultApplication = "3f0dd361-4fe0-5fc6-8523-80b14ec94d85"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterMarkdown = "997ab1e6-3595-5248-9280-8efb232c3433"
@@ -12,9 +12,9 @@ Glob = "c27321d9-0574-5035-807b-f59d2c89b15c"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Tar = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
 
 [compat]
-BinaryProvider = "0.5"
 DefaultApplication = "1"
 Documenter = "0.20, 0.21, 0.22, 0.23, 0.24, 0.25, 0.26"
 DocumenterMarkdown = "0.2"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,4 +1,4 @@
-import BinaryProvider
+import Tar, CodecZlib
 
 const _pkg_assets = joinpath(dirname(@__DIR__), "assets")
 
@@ -12,9 +12,16 @@ download(
 const tmp = joinpath(_pkg_assets, "tmp")
 !isdir(tmp) && mkdir(tmp)
 
-download("https://github.com/KaTeX/KaTeX/releases/download/v0.10.0/katex.tar.gz", joinpath(tmp, "katex.tar.gz"))
+const download_dir = joinpath(_pkg_assets, "download")
+!isdir(download_dir) && mkdir(download_dir)
 
-BinaryProvider.gen_unpack_cmd(joinpath(tmp, "katex.tar.gz"), tmp) |> run
+katex_compressed=joinpath(download_dir, "katex.tar.gz")
+
+download("https://github.com/KaTeX/KaTeX/releases/download/v0.10.0/katex.tar.gz", katex_compressed)
+
+open(CodecZlib.GzipDecompressorStream, katex_compressed) do io
+   Tar.extract(io, tmp)
+end
 
 const katexdir = joinpath(tmp, "katex")
 const katexfontdir = joinpath(katexdir, "fonts")
@@ -28,3 +35,4 @@ for file in ["katex.min.js", "katex.min.css", joinpath("contrib", "auto-render.m
 end
 
 rm(tmp, recursive=true)
+rm(download_dir, recursive=true)


### PR DESCRIPTION
Removing BuildProvider dependency given it does not work in M1.  Instead using Tar and CodecZlib.